### PR TITLE
Correct support email address

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -9,7 +9,7 @@
                 <li><a target="_blank" href="http://coc.golangbridge.org">CoC</a></li>
                 <li><a target="_blank" href="https://github.com/gobridge">Github</a></li>
             </ul>
-            <a class="text-link" href="mailto:support@golangbridge.com">support@golangbridge.com</a>
+            <a class="text-link" href="mailto:support@golangbridge.org">support@golangbridge.org</a>
         </div><!-- container -->
         <section>
             <p>© GoBridge 2015 - 2016. All rights reserved </p>


### PR DESCRIPTION
As mentioned in Slack, the support email points to an unregistered domain. I assume it should be `.org` instead of `.com`.