### PR TITLE
Add event details for the April GoBridge NYC workshop

### DIFF
--- a/data/events/2018-03-24.toml
+++ b/data/events/2018-03-24.toml
@@ -1,4 +1,0 @@
-title = "Workshop: Learn to Code using the Go Programming Language"
-where = "Baltimore, MD"
-when = "March 24th 2018 @ 8:30 AM  EST (US & Canada)"
-link = "https://www.bridgetroll.org/events/387"

--- a/data/events/2018-04-28.toml
+++ b/data/events/2018-04-28.toml
@@ -1,0 +1,4 @@
+title = "Workshop: Learn to Code using the Go Programming Language"
+where = "Brooklyn, NY"
+when = "April 28th 2018 @ 8:30 AM  EST (US & Canada)"
+link = "https://www.bridgetroll.org/events/395"


### PR DESCRIPTION
Updates the main events section with information for the upcoming GoBridge NYC workshop       scheduled for April 28th, 2018.

relates to https://github.com/gobridge/workshops/issues/43
